### PR TITLE
"Turn It On" seems dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Make sure 2FA or two step verification is enabled on all of the following accoun
 - [ ] Yahoo! - two step verification with SMS
 - [ ] LinkedIn - two step verification with SMS
 
-This is an incomplete list! For more information about two factor authentication, see [twofactorauth.org](https://twofactorauth.org/), [Turn It On](https://www.turnon2fa.com/), and [#LockDownURLogin](https://www.lockdownyourlogin.com/).
+This is an incomplete list! For more information about two factor authentication, see [twofactorauth.org](https://twofactorauth.org/), and [#LockDownURLogin](https://www.lockdownyourlogin.com/).


### PR DESCRIPTION
so maybe drop the link?

on https: `NET::ERR_CERT_COMMON_NAME_INVALID` "This server could not prove that it is www.turnon2fa.com; its security certificate is from shortener.secureserver.net. "
on http: gateway timeout